### PR TITLE
Add support to any type of file removing the snip line instead of comenting it

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,6 @@ $ ./a.out
 
 ## TODO
 
-- Add support to other languages: Only is needed to change the way to comment the `snip` line. eg: *cpp -> //*, *shell -> #*
 - Add cache to avoid downloading same code over again
 - Add namespaces to avoid eventual name collapsing
 

--- a/snip.sh
+++ b/snip.sh
@@ -2,12 +2,10 @@
 
 # TODO: use cache
 
-__snip__comment_out_snip_line() {
+__snip__remove_snip_line() {
   local source_file
   source_file="${1:?Missing source file as param}"
-
-  cpp_comment="//"
-  sed "s@^[ \t]*snip@${cpp_comment}snip@" "$source_file"
+  sed "/^[ \t]*snip/d" "$source_file"
 }
 
 __snip__replace_snips() {
@@ -37,7 +35,7 @@ __snip__replace_snips() {
   local output_file=$prefix_tmp${extension:+.$extension}
   rm $prefix_tmp
 
-  __snip__comment_out_snip_line "$source_file" > "$output_file"
+  __snip__remove_snip_line "$source_file" > "$output_file"
   rm $prefix_tmp-*
   echo "$output_file"
 }


### PR DESCRIPTION
Close #1 

Removing the "snip line" is the easiest way to support any type of file.